### PR TITLE
LX-77 Rename JIT user_groups scope & claim

### DIFF
--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/AuthenticationUtils.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/AuthenticationUtils.kt
@@ -65,7 +65,7 @@ object OAuthConstants {
      * @see ClientRegistration
      */
     const val REDIRECT_URL_BASE = "{baseUrl}/{action}/oauth2/code/"
-    const val GD_USER_GROUPS_SCOPE = "gd_user_groups"
+    const val GD_USER_GROUPS_SCOPE = "urn.gooddata.scope/user_groups"
 }
 
 /**

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/JitProvisioningAuthenticationSuccessHandler.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/JitProvisioningAuthenticationSuccessHandler.kt
@@ -129,7 +129,7 @@ class JitProvisioningAuthenticationSuccessHandler(
         const val GIVEN_NAME = "given_name"
         const val FAMILY_NAME = "family_name"
         const val EMAIL = "email"
-        const val GD_USER_GROUPS = "gd_user_groups"
+        const val GD_USER_GROUPS = "urn.gooddata.user_groups"
         val mandatoryClaims = setOf(GIVEN_NAME, FAMILY_NAME, EMAIL)
     }
 }


### PR DESCRIPTION
There is a custom scope naming limitation (customScopeName <-> resourceServerIdentifier/scopeName) in the aws cognito OIDC provider, we need to rename our custom scope.