### PR TITLE
LX-129: Throw ResponseStatusException on missing claims

### DIFF
--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/JitProvisioningAuthenticationSuccessHandler.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/JitProvisioningAuthenticationSuccessHandler.kt
@@ -17,13 +17,15 @@ package com.gooddata.oauth2.server
 
 import kotlinx.coroutines.reactor.mono
 import mu.KotlinLogging
+import org.springframework.http.HttpStatus
 import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException
-import org.springframework.security.oauth2.core.OAuth2Error
-import org.springframework.security.oauth2.core.OAuth2ErrorCodes
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames.EMAIL
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames.FAMILY_NAME
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames.GIVEN_NAME
 import org.springframework.security.web.server.WebFilterExchange
 import org.springframework.security.web.server.authentication.ServerAuthenticationSuccessHandler
+import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Mono
 
 class JitProvisioningAuthenticationSuccessHandler(
@@ -91,8 +93,9 @@ class JitProvisioningAuthenticationSuccessHandler(
     /**
      * Thrown when OAuth2AuthenticationToken is missing mandatory claims.
      */
-    class MissingMandatoryClaimsException(missingClaims: List<String>) : OAuth2AuthenticationException(
-        OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN, "Missing mandatory claims: $missingClaims", null)
+    class MissingMandatoryClaimsException(missingClaims: List<String>) : ResponseStatusException(
+        HttpStatus.UNAUTHORIZED,
+        "Authorization failed. Missing mandatory claims: $missingClaims"
     )
 
     private fun checkMandatoryClaims(authenticationToken: OAuth2AuthenticationToken, organizationId: String) {
@@ -126,9 +129,6 @@ class JitProvisioningAuthenticationSuccessHandler(
     private fun <T> List<T>.equalsIgnoreOrder(other: List<T>) = this.size == other.size && this.toSet() == other.toSet()
 
     companion object Claims {
-        const val GIVEN_NAME = "given_name"
-        const val FAMILY_NAME = "family_name"
-        const val EMAIL = "email"
         const val GD_USER_GROUPS = "urn.gooddata.user_groups"
         val mandatoryClaims = setOf(GIVEN_NAME, FAMILY_NAME, EMAIL)
     }

--- a/gooddata-server-oauth2-autoconfigure/src/test/kotlin/JitProvisioningAuthenticationSuccessHandlerTest.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/test/kotlin/JitProvisioningAuthenticationSuccessHandlerTest.kt
@@ -15,10 +15,7 @@
  */
 package com.gooddata.oauth2.server
 
-import com.gooddata.oauth2.server.JitProvisioningAuthenticationSuccessHandler.Claims.EMAIL
-import com.gooddata.oauth2.server.JitProvisioningAuthenticationSuccessHandler.Claims.FAMILY_NAME
 import com.gooddata.oauth2.server.JitProvisioningAuthenticationSuccessHandler.Claims.GD_USER_GROUPS
-import com.gooddata.oauth2.server.JitProvisioningAuthenticationSuccessHandler.Claims.GIVEN_NAME
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -29,9 +26,13 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames.EMAIL
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames.FAMILY_NAME
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames.GIVEN_NAME
 import org.springframework.security.web.server.WebFilterExchange
 import strikt.api.expectThat
 import strikt.api.expectThrows
+import strikt.assertions.isEqualTo
 import strikt.assertions.isNull
 
 class JitProvisioningAuthenticationSuccessHandlerTest {
@@ -88,6 +89,10 @@ class JitProvisioningAuthenticationSuccessHandlerTest {
         expectThrows<JitProvisioningAuthenticationSuccessHandler.MissingMandatoryClaimsException> {
             handler.onAuthenticationSuccess(exchange, authentication)
                 .block()
+        }.and {
+            get { message }.isEqualTo(
+                "401 UNAUTHORIZED \"Authorization failed. Missing mandatory claims: [given_name, family_name, email]\""
+            )
         }
     }
 


### PR DESCRIPTION
Changing MissingMandatoryClaimsException to ResponseStatusException to show user details of the authentication failure.