### PR TITLE
feat: Cognito Logout Support

### DIFF
--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/CognitoLogoutHandler.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/CognitoLogoutHandler.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 GoodData Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gooddata.oauth2.server
+
+import mu.KotlinLogging
+import org.springframework.http.HttpRequest
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository
+import org.springframework.security.web.server.DefaultServerRedirectStrategy
+import org.springframework.security.web.server.WebFilterExchange
+import org.springframework.security.web.server.authentication.logout.ServerLogoutHandler
+import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler
+import org.springframework.web.util.UriComponentsBuilder
+import reactor.core.publisher.Mono
+import java.net.URI
+
+/**
+ * Realize logout if provider is Cognito
+ * Inspired by https://auth0.com/docs/quickstart/webapp/java-spring-boot/01-login#add-logout-to-your-application
+ * and https://rieckpil.de/oidc-logout-with-aws-cognito-and-spring-security/ with additional reference to
+ * https://docs.aws.amazon.com/cognito/latest/developerguide/logout-endpoint.html
+ *
+ * @param clientRegistrationRepository the repository for client registrations
+ * @param cognitoCustomDomain if defined, the Cognito is white-labeled by the custom domain name different
+ * from the `*amazonaws.com`
+ */
+class CognitoLogoutHandler(
+    private val clientRegistrationRepository: ReactiveClientRegistrationRepository,
+    private val cognitoCustomDomain: String?,
+) : ServerLogoutHandler, ServerLogoutSuccessHandler {
+
+    private val logger = KotlinLogging.logger {}
+    private val redirectStrategy = DefaultServerRedirectStrategy()
+
+    override fun logout(exchange: WebFilterExchange, authentication: Authentication?): Mono<Void> =
+        Mono.justOrEmpty(authentication)
+            .filter { it is OAuth2AuthenticationToken }
+            .cast(OAuth2AuthenticationToken::class.java)
+            .flatMap {
+                logoutUrl(exchange.exchange.request).flatMap { url ->
+                    redirectStrategy.sendRedirect(exchange.exchange, url)
+                }
+            }
+
+    override fun onLogoutSuccess(exchange: WebFilterExchange, authentication: Authentication): Mono<Void> =
+        logout(exchange, authentication)
+
+    private fun logoutUrl(request: HttpRequest): Mono<URI> =
+        clientRegistrationRepository.findByRegistrationId(request.uri.host)
+            .map { clientRegistration ->
+                Pair(clientRegistration, clientRegistration.issuer())
+            }.filter { (_, issuer) ->
+                issuer.isCognito() || issuer.hasCustomDomain()
+            }.map { (clientRegistration) ->
+                buildLogoutUrl(
+                    clientRegistration.endSessionEndpoint(),
+                    clientRegistration.clientId,
+                    request.uri.baseUrl()
+                )
+            }.doOnNext { logoutUrl ->
+                logger.debug { "Cognito logout URL: $logoutUrl" }
+            }
+
+    private fun ClientRegistration.issuer(): URI = providerDetails.configurationMetadata["issuer"].toString().toUri()
+
+    private fun ClientRegistration.endSessionEndpoint(): URI = providerDetails
+        .configurationMetadata["end_session_endpoint"].toString().toUri()
+
+    private fun URI.hasCustomDomain(): Boolean = cognitoCustomDomain != null && cognitoCustomDomain == host
+
+    private fun buildLogoutUrl(endSessionEndpoint: URI, clientId: String, logoutUri: URI): URI =
+        UriComponentsBuilder
+            .fromUri(endSessionEndpoint)
+            .queryParam("client_id", clientId)
+            .queryParam("logout_uri", logoutUri)
+            .build()
+            .toUri()
+}

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ServerOAuth2AutoConfiguration.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ServerOAuth2AutoConfiguration.kt
@@ -224,10 +224,11 @@ class ServerOAuth2AutoConfiguration {
         jwtDecoderFactory: ObjectProvider<ReactiveJwtDecoderFactory<ClientRegistration>>,
         loginAuthManager: ReactiveAuthenticationManager,
         urlSafeStateAuthorizationRequestResolver: ServerOAuth2AuthorizationRequestResolver,
-        // TODO the property serves for a temporary hack.
+        // TODO these properties serve as a temporary hack.
         //  So for now, we will keep this configuration property here.
         //  Can be moved elsewhere or even removed in the following library release.
         @Value("\${spring.security.oauth2.config.provider.auth0.customDomain:#{null}}") auth0CustomDomain: String?,
+        @Value("\${spring.security.oauth2.config.provider.cognito.customDomain:#{null}}") cognitoCustomDomain: String?,
     ): SecurityWebFilterChain {
         val appLoginRedirectProcessor = AppLoginRedirectProcessor(
             appLoginProperties,
@@ -252,7 +253,8 @@ class ServerOAuth2AutoConfiguration {
                 setPostLogoutRedirectUri("{baseUrl}")
                 setLogoutSuccessUrl(URI.create("/"))
             },
-            // Keep Auth0 handler as last one in OIDC handlers
+            // Keep custom OIDC handlers as last in OIDC handlers
+            CognitoLogoutHandler(clientRegistrationRepository, cognitoCustomDomain),
             Auth0LogoutHandler(clientRegistrationRepository, auth0CustomDomain),
             JwtAuthenticationLogoutHandler(authenticationStoreClient.`object`),
             client = authenticationStoreClient.`object`,

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/UriExtensions.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/UriExtensions.kt
@@ -20,3 +20,11 @@ fun URI.baseUrl(): URI = UriComponentsBuilder.newInstance().scheme(scheme).host(
  * Check if URI is Auth0 issuer
  */
 fun URI.isAuth0(): Boolean = host?.lowercase()?.endsWith("auth0.com") ?: false
+
+/**
+ * Check if URI is Cognito issuer
+ */
+fun URI.isCognito(): Boolean {
+    val lowerCasedHost = host?.lowercase() ?: return false
+    return lowerCasedHost.endsWith("amazonaws.com") && lowerCasedHost.startsWith("cognito-idp")
+}

--- a/gooddata-server-oauth2-autoconfigure/src/test/kotlin/UriExtensionsTest.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/test/kotlin/UriExtensionsTest.kt
@@ -4,6 +4,8 @@
 package com.gooddata.oauth2.server
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
@@ -34,5 +36,23 @@ class UriExtensionsTest {
     fun `invalid Auth0 issuer`() {
         val uri = "https://auth0.example.org".toUri()
         expectThat(uri.isAuth0()).isFalse()
+    }
+
+    @Test
+    fun `valid Cognito issuer`() {
+        val uri = "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abcd1234".toUri()
+        expectThat(uri.isCognito()).isTrue()
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = [
+        "https://amazonaws.cognito-idp.example.org",
+        "https://amazonaws.example.org",
+        "https://cognito-idp.amazonaws.example.com",
+        "https://cognito-idp.example.com"
+    ])
+    fun `invalid Cognito issuer`(issuer: String) {
+        val uri = issuer.toUri()
+        expectThat(uri.isCognito()).isFalse()
     }
 }


### PR DESCRIPTION
As Cognito does not current support RP-Initiated logout, adding a cognito specific logout handler. Similar to existing Auth0LogoutHandler, this handler builds logout URL that conforms to Cognito's spec, getting the `end_session_endpoint` from the Cognito OpenID Configuration metadata.

JIRA: NAS-4728
risk: low