### PR TITLE
feat(oidc): support external provider in authorization requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ OIDC related data (access code, id token and refresh token) is stored in HTTP co
     * Access token, Refresh token
 * **SPRING_SEC_SECURITY_CONTEXT**
     * ID token
-* **REDIRECT_URI**
+* **SPRING_REDIRECT_URI**
     * original requested URI before authentication redirects
+* **SPRING_EXTERNAL_IDP**
+    * only needed for building the OAuth2 authorization request, contains the external provider identifier
+      (used for OIDC federation)
 
 Relevant Spring Security POJOs are serialized to JSON, base64 encoded and stored into HTTP response cookies.
 When cookie needs to be invalidated, its maxAge is set to 0.
@@ -89,6 +92,7 @@ root@a45628275f4a:/# ./tinkey create-keyset --key-template AES256_GCM
     * clears `SPRING_SEC_OAUTH2_AUTHZ_CLIENT`, `SPRING_SEC_SECURITY_CONTEXT` - i.e. OAuth2 tokens
 * **/appLogin**
     * resource that handles unauthenticated requests and redirects authenticated to `redirectTo` query parameter
+    * additional `externalProviderId` query parameter can be used to specify external provider for OIDC federation
 
 ### Multiple organizations support
 

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/AppLoginWebFilter.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/AppLoginWebFilter.kt
@@ -28,7 +28,6 @@ import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
 import org.springframework.web.util.UriComponentsBuilder
 import reactor.core.publisher.Mono
-import reactor.kotlin.core.publisher.switchIfEmpty
 import java.net.URI
 
 /**
@@ -61,7 +60,6 @@ class AppLoginWebFilter(private val appLoginRedirectProcessor: AppLoginRedirectP
  */
 class AppLoginRedirectProcessor(
     private val properties: AppLoginProperties,
-    private val authenticationStoreClient: AuthenticationStoreClient,
 ) {
     private val logger = KotlinLogging.logger {}
 

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/CookieUtils.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/CookieUtils.kt
@@ -38,3 +38,8 @@ const val SPRING_SEC_SECURITY_CONTEXT = "SPRING_SEC_SECURITY_CONTEXT"
  * Cookie key for storing serialized redirect URI.
  */
 const val SPRING_REDIRECT_URI = "SPRING_REDIRECT_URI"
+
+/**
+ * Cookie key for storing serialized federated identity provider ID.
+ */
+const val SPRING_EXTERNAL_IDP = "SPRING_EXTERNAL_IDP"

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ServerOAuth2AutoConfiguration.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ServerOAuth2AutoConfiguration.kt
@@ -15,6 +15,8 @@
  */
 package com.gooddata.oauth2.server
 
+import com.gooddata.oauth2.server.oauth2.client.FederationAwareOauth2AuthorizationRequestResolver
+import java.util.Base64
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -63,7 +65,6 @@ import org.springframework.util.ClassUtils
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource
 import org.springframework.web.reactive.config.EnableWebFlux
-import java.util.*
 
 @AutoConfiguration
 @EnableConfigurationProperties(
@@ -205,6 +206,15 @@ class ServerOAuth2AutoConfiguration {
         }
     }
 
+    /**
+     * Resolver which support OIDC federation.
+     */
+    @Bean
+    fun federationAwareAuthorizationRequestResolver(
+        urlSafeStateAuthorizationRequestResolver: ServerOAuth2AuthorizationRequestResolver,
+        cookieService: ReactiveCookieService,
+    ) = FederationAwareOauth2AuthorizationRequestResolver(urlSafeStateAuthorizationRequestResolver, cookieService)
+
     @Bean
     @Suppress("LongParameterList", "LongMethod")
     fun springSecurityFilterChain(
@@ -221,7 +231,7 @@ class ServerOAuth2AutoConfiguration {
         grantedAuthoritiesMapper: ObjectProvider<GrantedAuthoritiesMapper>,
         jwtDecoderFactory: ObjectProvider<ReactiveJwtDecoderFactory<ClientRegistration>>,
         loginAuthManager: ReactiveAuthenticationManager,
-        urlSafeStateAuthorizationRequestResolver: ServerOAuth2AuthorizationRequestResolver,
+        federationAwareAuthorizationRequestResolver: ServerOAuth2AuthorizationRequestResolver,
         // TODO these properties serve as a temporary hack.
         //  So for now, we will keep this configuration property here.
         //  Can be moved elsewhere or even removed in the following library release.
@@ -291,7 +301,7 @@ class ServerOAuth2AutoConfiguration {
                 authorizedClientRepository = oauth2ClientRepository
                 authenticationFailureHandler = ServerOAuth2FailureHandler()
                 authenticationManager = loginAuthManager
-                authorizationRequestResolver = urlSafeStateAuthorizationRequestResolver
+                authorizationRequestResolver = federationAwareAuthorizationRequestResolver
                 authenticationSuccessHandler = authSuccessHandler
             }
             oauth2Client { }

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ServerOAuth2AutoConfiguration.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ServerOAuth2AutoConfiguration.kt
@@ -228,10 +228,7 @@ class ServerOAuth2AutoConfiguration {
         @Value("\${spring.security.oauth2.config.provider.auth0.customDomain:#{null}}") auth0CustomDomain: String?,
         @Value("\${spring.security.oauth2.config.provider.cognito.customDomain:#{null}}") cognitoCustomDomain: String?,
     ): SecurityWebFilterChain {
-        val appLoginRedirectProcessor = AppLoginRedirectProcessor(
-            appLoginProperties,
-            authenticationStoreClient.`object`,
-        )
+        val appLoginRedirectProcessor = AppLoginRedirectProcessor(appLoginProperties)
         val serverRequestCache = DelegatingServerRequestCache(
             CookieServerRequestCache(cookieService),
             AppLoginCookieRequestCacheWriter(cookieService),

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/oauth2/client/FederationAwareOauth2AuthorizationRequestResolver.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/oauth2/client/FederationAwareOauth2AuthorizationRequestResolver.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 GoodData Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gooddata.oauth2.server.oauth2.client
+
+import com.gooddata.oauth2.server.ReactiveCookieService
+import com.gooddata.oauth2.server.SPRING_EXTERNAL_IDP
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.switchIfEmpty
+
+/**
+ * The implementation of [ServerOAuth2AuthorizationRequestResolver] that is able to append external identity provider
+ * (OIDC federation) info to authorization requests based on [SPRING_EXTERNAL_IDP] cookie in the [ServerWebExchange].
+ *
+ * It wraps the default [ServerOAuth2AuthorizationRequestResolver] which is responsible for building of the original
+ * authorization request with standard parameters.
+ *
+ * When the [SPRING_EXTERNAL_IDP] cookie is present it also clears it because it is not needed anymore.
+ *
+ * The new query parameter is Cognito-specific for now, so this does not ensure support for other identity providers.
+ *
+ * @param defaultResolver the default [ServerOAuth2AuthorizationRequestResolver] to be wrapped
+ * @param cookieService the [ReactiveCookieService] to be used for cookie handling
+ */
+class FederationAwareOauth2AuthorizationRequestResolver(
+    private val defaultResolver: ServerOAuth2AuthorizationRequestResolver,
+    private val cookieService: ReactiveCookieService,
+) : ServerOAuth2AuthorizationRequestResolver {
+    override fun resolve(exchange: ServerWebExchange?): Mono<OAuth2AuthorizationRequest> =
+        defaultResolver.resolve(exchange).flatMap { authorizationRequest ->
+            enhanceRequestByExternalIdentityParam(authorizationRequest, exchange)
+        }
+
+    override fun resolve(
+        exchange: ServerWebExchange?,
+        clientRegistrationId: String?,
+    ): Mono<OAuth2AuthorizationRequest> =
+        defaultResolver.resolve(exchange, clientRegistrationId).flatMap { authorizationRequest ->
+            enhanceRequestByExternalIdentityParam(authorizationRequest, exchange)
+        }
+
+    /**
+     * Enhances the provided [authorizationRequest] with external identity provider info based
+     * on the [SPRING_EXTERNAL_IDP] cookie existence. If the cookie is present, it is cleared.
+     */
+    private fun enhanceRequestByExternalIdentityParam(
+        authorizationRequest: OAuth2AuthorizationRequest,
+        exchange: ServerWebExchange?,
+    ): Mono<OAuth2AuthorizationRequest> = Mono.justOrEmpty(exchange)
+        .flatMap { existingExchange ->
+            cookieService.decodeCookie(existingExchange, SPRING_EXTERNAL_IDP).map { externalIdp ->
+                // invalidate cookie because it is not needed anymore
+                cookieService.invalidateCookie(existingExchange, SPRING_EXTERNAL_IDP)
+                OAuth2AuthorizationRequest.from(authorizationRequest)
+                    .additionalParameters { additionalParams ->
+                        // for now, only Cognito federation is supported
+                        additionalParams[COGNITO_EXTERNAL_PROVIDER_ID_PARAM_NAME] = externalIdp
+                    }
+                    .build()
+            }
+        }
+        .switchIfEmpty {
+            Mono.just(authorizationRequest)
+        }
+
+    companion object {
+        /**
+         * Cognito-specific query parameter for external identity provider ID.
+         * See https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html#get-authorize.
+         */
+        private const val COGNITO_EXTERNAL_PROVIDER_ID_PARAM_NAME = "idp_identifier"
+    }
+}

--- a/gooddata-server-oauth2-autoconfigure/src/test/kotlin/AppLoginCookieRequestCacheWriterTest.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/test/kotlin/AppLoginCookieRequestCacheWriterTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 GoodData Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gooddata.oauth2.server
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+@Suppress("ReactiveStreamsUnusedPublisher")
+class AppLoginCookieRequestCacheWriterTest {
+
+    private val cookieService: ReactiveCookieService = mockk {
+        every { createCookie(any(), any(), any()) } returns Mono.empty()
+    }
+
+    private val cacheWriter = AppLoginCookieRequestCacheWriter(cookieService)
+
+    @Test
+    fun `writes cache without external provider`() {
+        val redirectUri = "https://example.com/redirect"
+        val exchange = MockServerWebExchange.from(
+            MockServerHttpRequest.get("/appLogin").build()
+        )
+
+        StepVerifier.create(cacheWriter.saveRequest(exchange, redirectUri)).verifyComplete()
+
+        verify { cookieService.createCookie(exchange, SPRING_REDIRECT_URI, redirectUri) }
+    }
+
+    @Test
+    fun `writes cache with external provider`() {
+        val redirectUri = "https://example.com/redirect"
+        val externalProviderId = "xyz"
+        val exchange = MockServerWebExchange.from(
+            MockServerHttpRequest.get("/appLogin?externalProviderId=$externalProviderId").build()
+        )
+
+        StepVerifier.create(cacheWriter.saveRequest(exchange, redirectUri)).verifyComplete()
+
+        verify { cookieService.createCookie(exchange, SPRING_REDIRECT_URI, redirectUri) }
+        verify { cookieService.createCookie(exchange, SPRING_EXTERNAL_IDP, externalProviderId) }
+    }
+}

--- a/gooddata-server-oauth2-autoconfigure/src/test/kotlin/AppLoginRedirectProcessorTest.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/test/kotlin/AppLoginRedirectProcessorTest.kt
@@ -38,11 +38,9 @@ import java.net.URI
 
 @Suppress("ReactiveStreamsUnusedPublisher")
 internal class AppLoginRedirectProcessorTest {
-    private val client = mockk<AuthenticationStoreClient>()
     private val exchange = mockk<ServerWebExchange>()
     private val processor = AppLoginRedirectProcessor(
         AppLoginProperties(URI.create(GLOBAL_ALLOWED_URI)),
-        client,
     )
     private val processFun = mockk<(String) -> Mono<Void>> {
         every { this@mockk.invoke(any()) } returns Mono.empty()

--- a/gooddata-server-oauth2-autoconfigure/src/test/kotlin/oauth2/client/FederationAwareOauth2AuthorizationRequestResolverTest.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/test/kotlin/oauth2/client/FederationAwareOauth2AuthorizationRequestResolverTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 GoodData Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gooddata.oauth2.server.oauth2.client
+
+import com.gooddata.oauth2.server.ReactiveCookieService
+import com.gooddata.oauth2.server.SPRING_EXTERNAL_IDP
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+@Suppress("ReactiveStreamsUnusedPublisher")
+class FederationAwareOauth2AuthorizationRequestResolverTest {
+
+    private val defaultResolver: ServerOAuth2AuthorizationRequestResolver = mockk {
+        every { resolve(any()) } returns Mono.just(DEFAULT_AUTH_REQUEST)
+        every { resolve(any(), any()) } returns Mono.just(DEFAULT_AUTH_REQUEST)
+    }
+    private val cookieService: ReactiveCookieService = mockk {
+        every { decodeCookie(any(), any()) } returns Mono.empty()
+        every { invalidateCookie(any(), any()) } just runs
+    }
+
+    private val resolver = FederationAwareOauth2AuthorizationRequestResolver(defaultResolver, cookieService)
+
+    @Test
+    fun `resolve without cookie`() {
+        StepVerifier.create(oauthRequestToUri(resolver.resolve(EXCHANGE)))
+            .expectNext("https://example.com/oauth2/authorize?response_type=code&client_id=client-id")
+            .verifyComplete()
+    }
+
+    @Test
+    fun `resolve with cookie and invalidates it`() {
+        every { cookieService.decodeCookie(EXCHANGE, SPRING_EXTERNAL_IDP) } returns Mono.just("external-idp-id")
+
+        StepVerifier.create(oauthRequestToUri(resolver.resolve(EXCHANGE)))
+            .expectNext(
+                "https://example.com/oauth2/authorize" +
+                    "?response_type=code&client_id=client-id&idp_identifier=external-idp-id"
+            )
+            .verifyComplete()
+
+        verify { cookieService.invalidateCookie(EXCHANGE, SPRING_EXTERNAL_IDP) }
+    }
+
+    @Test
+    fun `resolve without cookie and client registration id`() {
+        StepVerifier.create(oauthRequestToUri(resolver.resolve(EXCHANGE, "registration-id")))
+            .expectNext("https://example.com/oauth2/authorize?response_type=code&client_id=client-id")
+            .verifyComplete()
+    }
+
+    companion object {
+        private val DEFAULT_AUTH_REQUEST = OAuth2AuthorizationRequest
+            .authorizationCode()
+            .authorizationUri("https://example.com/oauth2/authorize")
+            .clientId("client-id")
+            .build()
+
+        private val EXCHANGE = MockServerWebExchange.from(
+            MockServerHttpRequest.get("/oauth2/authorization/localhost")
+        )
+
+        private fun oauthRequestToUri(request: Mono<OAuth2AuthorizationRequest>): Mono<String> =
+            request.map(OAuth2AuthorizationRequest::getAuthorizationRequestUri)
+    }
+}


### PR DESCRIPTION
For now, only `idp_identifier` from Cognito is supported.

Jira: STL-790
risk: low