### PR TITLE
fix(oidc): switch to `identity_provider` query param in OIDC federation

### DIFF
--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/oauth2/client/FederationAwareOauth2AuthorizationRequestResolver.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/oauth2/client/FederationAwareOauth2AuthorizationRequestResolver.kt
@@ -83,6 +83,6 @@ class FederationAwareOauth2AuthorizationRequestResolver(
          * Cognito-specific query parameter for external identity provider ID.
          * See https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html#get-authorize.
          */
-        private const val COGNITO_EXTERNAL_PROVIDER_ID_PARAM_NAME = "idp_identifier"
+        private const val COGNITO_EXTERNAL_PROVIDER_ID_PARAM_NAME = "identity_provider"
     }
 }

--- a/gooddata-server-oauth2-autoconfigure/src/test/kotlin/oauth2/client/FederationAwareOauth2AuthorizationRequestResolverTest.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/test/kotlin/oauth2/client/FederationAwareOauth2AuthorizationRequestResolverTest.kt
@@ -58,7 +58,7 @@ class FederationAwareOauth2AuthorizationRequestResolverTest {
         StepVerifier.create(oauthRequestToUri(resolver.resolve(EXCHANGE)))
             .expectNext(
                 "https://example.com/oauth2/authorize" +
-                    "?response_type=code&client_id=client-id&idp_identifier=external-idp-id"
+                    "?response_type=code&client_id=client-id&identity_provider=external-idp-id"
             )
             .verifyComplete()
 


### PR DESCRIPTION
Cognito's `idp_identifier` searches for optional identifiers and `identity_provider` param searches for mandatory unique identifier
 of any external provider.

Jira: STL-790
risk: low