### PR TITLE
fix(oidc): cache "partial" client registrations instead of builders

### DIFF
--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ClientRegistrationCache.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ClientRegistrationCache.kt
@@ -19,17 +19,21 @@ package com.gooddata.oauth2.server
 import org.springframework.security.oauth2.client.registration.ClientRegistration
 
 /**
- * Stores client registration builders
+ * Stores partial client registrations.
+ *
+ * Partial means that the registration is not fully initialized and may be missing some required properties
+ * for being able to start authorization flow properly. This means that after the using of this cache,
+ * you need to set up additional properties.
  */
-interface ClientRegistrationBuilderCache : Cache<String, ClientRegistration.Builder>
+interface ClientRegistrationCache : Cache<String, ClientRegistration>
 
 /**
  * Caffeine implementation of client registration builders cache.
  * @param maxSize max cache size. Default is [CaffeineCache.CACHE_MAX_SIZE].
- * @param expireAfterWriteMinutes cached values are expired after write after this value in minutes. Default is
+ * @param expireAfterWriteMinutes cached values are expired after write this value in minutes. Default is
  * [CaffeineCache.CACHE_EXPIRE_AFTER_WRITE_MINUTES].
  */
 class CaffeineClientRegistrationCache(
     maxSize: Long = CACHE_MAX_SIZE,
     expireAfterWriteMinutes: Long = CACHE_EXPIRE_AFTER_WRITE_MINUTES
-) : ClientRegistrationBuilderCache, CaffeineCache<String, ClientRegistration.Builder>(maxSize, expireAfterWriteMinutes)
+) : ClientRegistrationCache, CaffeineCache<String, ClientRegistration>(maxSize, expireAfterWriteMinutes)

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/HostBasedReactiveClientRegistrationRepository.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/HostBasedReactiveClientRegistrationRepository.kt
@@ -25,7 +25,7 @@ import reactor.core.publisher.Mono
  */
 class HostBasedReactiveClientRegistrationRepository(
     private val properties: HostBasedClientRegistrationRepositoryProperties,
-    private val clientRegistrationBuilderCache: ClientRegistrationBuilderCache,
+    private val clientRegistrationCache: ClientRegistrationCache,
 ) : ReactiveClientRegistrationRepository {
 
     override fun findByRegistrationId(registrationId: String): Mono<ClientRegistration> =
@@ -34,7 +34,7 @@ class HostBasedReactiveClientRegistrationRepository(
                 registrationId = registrationId,
                 organization = it,
                 properties = properties,
-                clientRegistrationBuilderCache = clientRegistrationBuilderCache,
+                clientRegistrationCache = clientRegistrationCache,
             )
         }
 }

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ServerOAuth2AutoConfiguration.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ServerOAuth2AutoConfiguration.kt
@@ -114,13 +114,13 @@ class ServerOAuth2AutoConfiguration {
     fun clientRegistrationRepository(
         client: ObjectProvider<AuthenticationStoreClient>,
         properties: HostBasedClientRegistrationRepositoryProperties,
-        clientRegistrationBuilderCache: ClientRegistrationBuilderCache,
+        clientRegistrationCache: ClientRegistrationCache,
     ): ReactiveClientRegistrationRepository =
-        HostBasedReactiveClientRegistrationRepository(properties, clientRegistrationBuilderCache)
+        HostBasedReactiveClientRegistrationRepository(properties, clientRegistrationCache)
 
-    @ConditionalOnMissingBean(ClientRegistrationBuilderCache::class)
+    @ConditionalOnMissingBean(ClientRegistrationCache::class)
     @Bean
-    fun clientRegistrationCache(cachingProperties: CachingProperties): ClientRegistrationBuilderCache =
+    fun clientRegistrationCache(cachingProperties: CachingProperties): ClientRegistrationCache =
         CaffeineClientRegistrationCache(
             cachingProperties.clientRegistrationMaxSize,
             cachingProperties.clientRegistrationExpireAfterWriteMinutes

--- a/gooddata-server-oauth2-autoconfigure/src/test/kotlin/AuthenticationUtilsTest.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/test/kotlin/AuthenticationUtilsTest.kt
@@ -59,12 +59,12 @@ internal class AuthenticationUtilsTest {
 
     lateinit var properties: HostBasedClientRegistrationRepositoryProperties
 
-    lateinit var clientRegistrationBuilderCache: ClientRegistrationBuilderCache
+    lateinit var clientRegistrationCache: ClientRegistrationCache
 
     @BeforeEach
     internal fun setUp() {
         properties = HostBasedClientRegistrationRepositoryProperties("http://remote", "http://localhost")
-        clientRegistrationBuilderCache = CaffeineClientRegistrationCache()
+        clientRegistrationCache = CaffeineClientRegistrationCache()
     }
 
     @Test
@@ -79,7 +79,7 @@ internal class AuthenticationUtilsTest {
             REGISTRATION_ID,
             organization,
             properties,
-            clientRegistrationBuilderCache
+            clientRegistrationCache
         )
         expect {
             that(clientRegistration).and {
@@ -107,7 +107,7 @@ internal class AuthenticationUtilsTest {
                 REGISTRATION_ID,
                 organization,
                 properties,
-                clientRegistrationBuilderCache
+                clientRegistrationCache
             )
         }
         expect {
@@ -135,7 +135,7 @@ internal class AuthenticationUtilsTest {
             oauthClientSecret = CLIENT_SECRET
         )
 
-        expectThat(buildClientRegistration(REGISTRATION_ID, organization, properties, clientRegistrationBuilderCache)) {
+        expectThat(buildClientRegistration(REGISTRATION_ID, organization, properties, clientRegistrationCache)) {
             get { registrationId }.isEqualTo(REGISTRATION_ID)
             get { clientId }.isEqualTo(CLIENT_ID)
             get { clientSecret }.isEqualTo(CLIENT_SECRET)
@@ -155,7 +155,7 @@ internal class AuthenticationUtilsTest {
         )
 
         try {
-            buildClientRegistration(REGISTRATION_ID, organization, properties, clientRegistrationBuilderCache)
+            buildClientRegistration(REGISTRATION_ID, organization, properties, clientRegistrationCache)
         } catch (ex: HttpClientErrorException) {
             // This is expected as the issuer isn't actually available and can be ignored as we just wish to verify
             // that the `handleAzureB2CClientRegistration` method is called when the issuer is an Azure B2C issuer.
@@ -215,7 +215,7 @@ internal class AuthenticationUtilsTest {
         )
 
         val ex = assertThrows<ResponseStatusException> {
-            buildClientRegistration(REGISTRATION_ID, organization, properties, clientRegistrationBuilderCache)
+            buildClientRegistration(REGISTRATION_ID, organization, properties, clientRegistrationCache)
         }
         assertEquals(
             "401 UNAUTHORIZED \"Authorization failed for given issuer \"$issuerLocation\". $messageSpecification",
@@ -234,7 +234,7 @@ internal class AuthenticationUtilsTest {
         )
 
         val ex = assertThrows<ResponseStatusException> {
-            buildClientRegistration(REGISTRATION_ID, organization, properties, clientRegistrationBuilderCache)
+            buildClientRegistration(REGISTRATION_ID, organization, properties, clientRegistrationCache)
         }
         assertEquals(
             "401 UNAUTHORIZED \"Authorization failed for given issuer $issuer. " +


### PR DESCRIPTION
Builders have mutable state which could be changed during the parallel processing. The registrations themselves are immutable.

"partial" means that only fields filled from well-known endpoints are cached. Other fields like e.g. registration ID are filled with dummy data which are needed to pass `builder.build()` step.

Jira: STL-912
risk: low