### PR TITLE
fix: Fix user patching in JIT provisioning

### DIFF
--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/JitProvisioningAuthenticationSuccessHandler.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/JitProvisioningAuthenticationSuccessHandler.kt
@@ -78,7 +78,9 @@ class JitProvisioningAuthenticationSuccessHandler(
                     user.firstname = firstnameClaim
                     user.lastname = lastnameClaim
                     user.email = emailClaim
-                    user.userGroups = userGroupsClaim
+                    if (userGroupsClaim != null) {
+                        user.userGroups = userGroupsClaim
+                    }
                     client.patchUser(organization.id, user)
                 } else {
                     logMessage("User not changed, skipping update", "finished", organization.id)


### PR DESCRIPTION
Fixing a bug in JIT provisioning.
When user details have changed and at the same time user groups were not present in the token, this effectively ended up in wiping out users current user groups.

Now we update users user groups only if during the JIT the userGroups claim is not NULL (empty list is still valid)

JIRA: LX-341
risk: low