### PR TITLE
fix: hostname if address is null (audit sourceIp)

### DIFF
--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/BearerTokenReactiveAuthenticationManagerResolver.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/BearerTokenReactiveAuthenticationManagerResolver.kt
@@ -45,6 +45,7 @@ class BearerTokenReactiveAuthenticationManagerResolver(
     override fun resolve(exchange: ServerWebExchange): Mono<ReactiveAuthenticationManager> =
         Mono.just(exchange).map {
             val sourceIp = exchange.request.remoteAddress?.address?.hostAddress
+                ?: exchange.request.remoteAddress?.hostName
 
             CustomDelegatingReactiveAuthenticationManager(
                 JwtAuthenticationManager(client, auditClient, sourceIp),
@@ -61,7 +62,6 @@ private class PersistentApiTokenAuthenticationManager(
     private val auditClient: AuthenticationAuditClient,
     private val sourceIp: String?,
 ) : ReactiveAuthenticationManager {
-    private val logger = KotlinLogging.logger { }
 
     override fun authenticate(authentication: Authentication?): Mono<Authentication> =
         Mono.justOrEmpty(authentication)

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/DelegatingServerLogoutSuccessHandler.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/DelegatingServerLogoutSuccessHandler.kt
@@ -27,6 +27,7 @@ class DelegatingServerLogoutSuccessHandler(
     @Suppress("CyclomaticComplexMethod")
     override fun onLogoutSuccess(exchange: WebFilterExchange, authentication: Authentication): Mono<Void> {
         val sourceIp = exchange.exchange.request.remoteAddress?.address?.hostAddress
+            ?: exchange.exchange.request.remoteAddress?.hostName
 
         return Flux.fromIterable(delegates).concatMap { delegate ->
             delegate.onLogoutSuccess(exchange, authentication)

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/LoggingRedirectServerAuthenticationSuccessHandler.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/LoggingRedirectServerAuthenticationSuccessHandler.kt
@@ -24,6 +24,7 @@ class LoggingRedirectServerAuthenticationSuccessHandler(
         authentication: Authentication?,
     ): Mono<Void> {
         val sourceIp = webFilterExchange?.exchange?.request?.remoteAddress?.address?.hostAddress
+            ?: webFilterExchange?.exchange?.request?.remoteAddress?.hostName
 
         return super.onAuthenticationSuccess(webFilterExchange, authentication)
             .then(

--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ServerOAuth2FailureHandler.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ServerOAuth2FailureHandler.kt
@@ -38,6 +38,7 @@ class ServerOAuth2FailureHandler(
 
         return getOrganizationFromContext().flatMap { organization ->
             val sourceIp = exchange.exchange.request.remoteAddress?.address?.hostAddress
+                ?: exchange.exchange.request.remoteAddress?.hostName
             auditClient.recordLoginFailure(
                 orgId = organization.id,
                 userId = "",


### PR DESCRIPTION
Adding fallback to hostname if the address is `null` as the IP can be saved as the hostname.

JIRA: LX-858
risk: low