### PR TITLE
fix: Move SPRING_REDIRECT_URI cookie invalidation to correct place

### DIFF
--- a/gooddata-server-oauth2-autoconfigure/src/test/kotlin/CookieServerRequestCacheTest.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/test/kotlin/CookieServerRequestCacheTest.kt
@@ -23,10 +23,12 @@ import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import io.netty.handler.codec.http.cookie.CookieHeaderNames
+import java.net.URI
+import java.time.Duration
+import java.time.Instant
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpCookie
-import org.springframework.http.HttpStatus
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest
 import org.springframework.mock.web.server.MockServerWebExchange
 import org.springframework.util.CollectionUtils
@@ -35,10 +37,6 @@ import reactor.core.publisher.Mono
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isTrue
-import java.net.URI
-import java.time.Duration
-import java.time.Instant
-import strikt.assertions.isNotNull
 
 internal class CookieServerRequestCacheTest {
 
@@ -68,7 +66,9 @@ internal class CookieServerRequestCacheTest {
     """
 
     private val client: AuthenticationStoreClient = mockk {
-        mockCookieSecurityProperties(this, ORG_ID,
+        mockCookieSecurityProperties(
+            this,
+            ORG_ID,
             CookieSecurityProperties(
                 keySet = CleartextKeysetHandle.read(JsonKeysetReader.withBytes(keyset.toByteArray())),
                 lastRotation = Instant.now(),
@@ -98,22 +98,6 @@ internal class CookieServerRequestCacheTest {
         }
 
         verify(exactly = 1) { cookieService.createCookie(exchange, SPRING_REDIRECT_URI, any()) }
-    }
-
-    @Test
-    fun `should remove redirect URI from cookies`() {
-        val request = MockServerHttpRequest.get("http://localhost/requestURI").queryParam("query", "true").build()
-        val exchange = MockServerWebExchange.from(request)
-        every { cookieService.invalidateCookie(any(), any()) } returns Unit
-
-        val matchingRequest = cache.removeMatchingRequest(exchange)
-
-        expectThat(matchingRequest.blockOptional()) {
-            get { isPresent }.isTrue()
-            get { get() }.isEqualTo(request)
-        }
-
-        verify(exactly = 1) { cookieService.invalidateCookie(exchange, SPRING_REDIRECT_URI) }
     }
 
     @Test
@@ -169,11 +153,10 @@ internal class CookieServerRequestCacheTest {
     }
 
     @Test
-    fun `should preserve redirect URI during 401 response`() {
+    fun `should invalidate cookie after reading redirect URI`() {
         val webExchange = mockk<ServerWebExchange> {
             every { request.uri.host } returns "localhost"
             every { attributes[OrganizationWebFilter.ORGANIZATION_CACHE_KEY] } returns Organization(ORG_ID)
-            every { response.statusCode } returns HttpStatus.UNAUTHORIZED
         }
 
         val redirect = "/requestURI?query=true"
@@ -182,36 +165,12 @@ internal class CookieServerRequestCacheTest {
                 HttpCookie(SPRING_REDIRECT_URI, cookieSerializer.encodeCookieBlocking(webExchange, redirect))
             )
         )
-        exchange.response.statusCode = HttpStatus.UNAUTHORIZED
 
-        val request = cache.removeMatchingRequest(exchange).block()
+        val uri = cache.getRedirectUri(exchange).block()
 
-        // Verify the cookie was not invalidated
-        verify(exactly = 0) { cookieService.invalidateCookie(exchange, SPRING_REDIRECT_URI) }
-        expectThat(request).isNotNull()
-    }
+        expectThat(uri).isEqualTo(URI.create(redirect))
 
-    @Test
-    fun `should clear redirect URI for non-401 response`() {
-        val webExchange = mockk<ServerWebExchange> {
-            every { request.uri.host } returns "localhost"
-            every { attributes[OrganizationWebFilter.ORGANIZATION_CACHE_KEY] } returns Organization(ORG_ID)
-            every { response.statusCode } returns HttpStatus.FOUND
-        }
-
-        val redirect = "/requestURI?query=true"
-        val exchange = MockServerWebExchange.from(
-            MockServerHttpRequest.get("http://localhost/").cookie(
-                HttpCookie(SPRING_REDIRECT_URI, cookieSerializer.encodeCookieBlocking(webExchange, redirect))
-            )
-        )
-        exchange.response.statusCode = HttpStatus.FOUND
-
-        val request = cache.removeMatchingRequest(exchange).block()
-
-        // Verify the cookie was invalidated
         verify(exactly = 1) { cookieService.invalidateCookie(exchange, SPRING_REDIRECT_URI) }
-        expectThat(request).isNotNull()
     }
 
     companion object {

--- a/gooddata-server-oauth2-autoconfigure/src/test/kotlin/UserContextWebFluxTest.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/test/kotlin/UserContextWebFluxTest.kt
@@ -23,6 +23,8 @@ import com.ninjasquad.springmockk.SpykBean
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import java.time.Duration
+import java.time.Instant
 import net.javacrumbs.jsonunit.core.util.ResourceUtils
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
@@ -49,8 +51,6 @@ import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
 import reactor.util.context.Context
-import java.time.Duration
-import java.time.Instant
 
 @WebFluxTest(properties = ["spring.security.oauth2.client.applogin.allow-redirect=https://localhost:8443"])
 @Import(ServerOAuth2AutoConfiguration::class, UserContextWebFluxTest.Config::class)
@@ -512,7 +512,6 @@ class UserContextWebFluxTest(
             .exchange()
             .expectStatus().isFound
             .expectHeader().location("/")
-            .expectCookie().exists("SPRING_REDIRECT_URI")
     }
 
     @Test
@@ -543,7 +542,6 @@ class UserContextWebFluxTest(
             .exchange()
             .expectStatus().isFound
             .expectHeader().location("/userReturnTo")
-            .expectCookie().exists("SPRING_REDIRECT_URI")
     }
 
     @Test
@@ -582,7 +580,6 @@ class UserContextWebFluxTest(
             .exchange()
             .expectStatus().isFound
             .expectHeader().location("/")
-            .expectCookie().exists("SPRING_REDIRECT_URI")
     }
 
     @Test
@@ -621,7 +618,6 @@ class UserContextWebFluxTest(
             .exchange()
             .expectStatus().isFound
             .expectHeader().location("/userReturnTo")
-            .expectCookie().exists("SPRING_REDIRECT_URI")
     }
 
     @Test
@@ -634,7 +630,6 @@ class UserContextWebFluxTest(
         webClient.post().uri("http://localhost/logout")
             .exchange()
             .expectStatus().isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
-            .expectCookie().exists("SPRING_REDIRECT_URI")
     }
 
     @Test
@@ -647,7 +642,6 @@ class UserContextWebFluxTest(
         webClient.post().uri("http://localhost/logout/all")
             .exchange()
             .expectStatus().isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
-            .expectCookie().exists("SPRING_REDIRECT_URI")
     }
 
     private fun encodeCookieBlocking(authenticationToken: String) =


### PR DESCRIPTION
Invalidating SPRING_REDIRECT_URI cookie right after the cookie is read.

JIRA: LX-1022
risk: high