### PR TITLE
feat: Add a retry logic to oauth authentication client

### DIFF
--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/HttpProperties.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/HttpProperties.kt
@@ -29,7 +29,7 @@ class HttpProperties(
      * A timeout for receiving some response on a request. (in milliseconds)
      * @see SimpleClientHttpRequestFactory.setReadTimeout
      */
-    @DefaultValue("5000")
+    @DefaultValue("7000")
     val readTimeoutMillis: Int,
 
     /**


### PR DESCRIPTION
Increasing the read timeout from 5sec to 7sec.

The change aims to resolve Connection reset by peer error which appears from time to time while establishing tcp connection with the authentication server.