### PR TITLE
feat: honour JVM proxy system properties in reactive OAuth2 client

### DIFF
--- a/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ReactiveCommunicationClientsConfiguration.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/main/kotlin/ReactiveCommunicationClientsConfiguration.kt
@@ -59,6 +59,11 @@ class ReactiveCommunicationClientsConfiguration(private val httpProperties: Http
         val httpClient = HttpClient.create(connectionProvider())
             .responseTimeout(Duration.ofMillis(httpProperties.readTimeoutMillis.toLong()))
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, httpProperties.connectTimeoutMillis)
+            // Honour standard JVM proxy system properties (https.proxyHost, http.proxyHost,
+            // http.nonProxyHosts, etc.). Without this, the Reactor Netty client used for
+            // OIDC token, userinfo, and refresh-token calls silently bypasses any proxy that
+            // the JDK-based RestTemplate paths in this library already respect.
+            .proxyWithSystemProperties()
         return WebClient.builder()
             .clientConnector(ReactorClientHttpConnector(httpClient))
             .filter { request, next ->

--- a/gooddata-server-oauth2-autoconfigure/src/test/kotlin/ReactiveCommunicationClientsConfigurationTest.kt
+++ b/gooddata-server-oauth2-autoconfigure/src/test/kotlin/ReactiveCommunicationClientsConfigurationTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 GoodData Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gooddata.oauth2.server
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.client.reactive.ClientHttpConnector
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import reactor.netty.transport.ProxyProvider
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isNotNull
+import strikt.assertions.isTrue
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
+class ReactiveCommunicationClientsConfigurationTest {
+
+    private val httpProperties = HttpProperties(
+        readTimeoutMillis = 10_000,
+        connectTimeoutMillis = 30_000,
+        connectionIdleTimeoutMillis = 300_000,
+    )
+
+    @Test
+    fun `customWebClient is not configured with a proxy when no JVM proxy system properties are set`() {
+        withSystemProperties(emptyMap()) {
+            val webClient = ReactiveCommunicationClientsConfiguration(httpProperties).customWebClient()
+
+            expectThat(webClient.httpClient().configuration().hasProxy()).isFalse()
+        }
+    }
+
+    @Suppress("DEPRECATION") // ProxyProvider.getAddress has no non-deprecated replacement in Reactor Netty 1.2.x
+    @Test
+    fun `customWebClient picks up the standard JVM https proxy system properties`() {
+        withSystemProperties(
+            mapOf(
+                "https.proxyHost" to PROXY_HOST,
+                "https.proxyPort" to PROXY_PORT.toString(),
+            )
+        ) {
+            val webClient = ReactiveCommunicationClientsConfiguration(httpProperties).customWebClient()
+            val config = webClient.httpClient().configuration()
+
+            expectThat(config.hasProxy()).isTrue()
+            val provider = config.proxyProviderSupplier()!!.get()
+            expectThat(provider).isNotNull().and {
+                get { type }.isEqualTo(ProxyProvider.Proxy.HTTP)
+                get { address.get().hostString }.isEqualTo(PROXY_HOST)
+                get { address.get().port }.isEqualTo(PROXY_PORT)
+            }
+        }
+    }
+
+    private fun WebClient.httpClient(): HttpClient {
+        val exchangeFunction: ExchangeFunction = readField("exchangeFunction", this)
+        val connector: ClientHttpConnector = readField("connector", exchangeFunction)
+        return readField("httpClient", connector)
+    }
+
+    private fun withSystemProperties(properties: Map<String, String>, block: () -> Unit) {
+        val previous = properties.keys.associateWith { System.getProperty(it) }
+        try {
+            properties.forEach { (key, value) -> System.setProperty(key, value) }
+            block()
+        } finally {
+            previous.forEach { (key, value) ->
+                if (value == null) System.clearProperty(key) else System.setProperty(key, value)
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T, R : Any> readField(fieldName: String, instance: R): T {
+        val field = instance::class.memberProperties.find { it.name == fieldName } as KProperty1<R, *>
+        field.isAccessible = true
+        return field.get(instance) as T
+    }
+
+    companion object {
+        private const val PROXY_HOST = "proxy.example.com"
+        private const val PROXY_PORT = 8443
+    }
+}


### PR DESCRIPTION
## Summary

The `customWebClient` used by Spring Security's reactive OAuth2 client for **token exchange, userinfo, and refresh-token** calls is built on Reactor Netty's `HttpClient`, which does not consult JVM proxy system properties by default. The JDK-based `RestTemplate` paths in this same library *do* consult them (`ClientRegistrations.fromIssuerLocation` for OIDC discovery, `SimpleRemoteJwkSource` for JWKS), creating a partial-proxy behaviour where OIDC discovery and JWKS calls go through a corporate proxy but token/userinfo/refresh calls silently bypass it.

Symptom for a customer behind a corporate egress proxy: the browser-side redirect to the IdP completes and credentials work, but the server-side callback (token exchange) hangs or 502s because the auth-service pod cannot reach the IdP's token endpoint directly.

Adding `.proxyWithSystemProperties()` to the `HttpClient` chain closes the gap. The call is a no-op when no proxy system properties are set, so customers who do not configure a proxy see no behaviour change.

## What changed

- `gooddata-server-oauth2-autoconfigure/src/main/kotlin/ReactiveCommunicationClientsConfiguration.kt:62-66` — one chained call on the `HttpClient` builder, plus a comment explaining the rationale.
- `gooddata-server-oauth2-autoconfigure/src/test/kotlin/ReactiveCommunicationClientsConfigurationTest.kt` — new unit test asserting both states (no proxy props ⇒ `hasProxy()` is false; `https.proxyHost`/`https.proxyPort` set ⇒ supplier-backed HTTP `ProxyProvider` matches host/port).

## Test plan

- [x] `./gradlew :gooddata-server-oauth2-autoconfigure:test` — 261 tests pass (2 new, 259 pre-existing)
- [x] `./gradlew :gooddata-server-oauth2-autoconfigure:detekt :gooddata-server-oauth2-autoconfigure:detektTest` — clean
- [ ] Verified end-to-end against a real IdP behind a corporate proxy (cannot reproduce locally; recommend a consumer (`gdc-nas` auth-service) deploy and smoke-test login flow)

## Notes on `proxyProviderSupplier` vs `proxyProvider`

Reactor Netty 1.2.x stores system-property-derived proxies as a `Supplier<ProxyProvider>` (lazy) on `ClientTransportConfig`, separate from the eager `ProxyProvider` field. `hasProxy()` is the right boolean check, since `proxyProvider()` alone returns `null` even when a supplier-backed proxy is configured. The test asserts against both to make this explicit.

## Risk

`risk: low` — additive call that is a no-op for customers who do not set JVM proxy system properties. Behaviour for OIDC-only customers without a proxy is unchanged.

JIRA: TRIVIAL